### PR TITLE
feat: use gentx-gravity instead of gentx

### DIFF
--- a/ignite/chainconfig/config.go
+++ b/ignite/chainconfig/config.go
@@ -88,8 +88,10 @@ type Account struct {
 
 // Validator holds info related to validator settings.
 type Validator struct {
-	Name   string `yaml:"name"`
-	Staked string `yaml:"staked"`
+	Name        string `yaml:"name"`
+	Staked      string `yaml:"staked"`
+	EthAddress  string `yaml:"eth_address"`
+	OrchAddress string `yaml:"orch_address"`
 }
 
 // Build holds build configs.

--- a/ignite/pkg/chaincmd/chaincmd.go
+++ b/ignite/pkg/chaincmd/chaincmd.go
@@ -12,7 +12,7 @@ const (
 	commandInit              = "init"
 	commandKeys              = "keys"
 	commandAddGenesisAccount = "add-genesis-account"
-	commandGentx             = "gentx"
+	commandGentx             = "gentx-gravity"
 	commandCollectGentxs     = "collect-gentxs"
 	commandValidateGenesis   = "validate-genesis"
 	commandShowNodeID        = "show-node-id"
@@ -414,36 +414,25 @@ func (c ChainCmd) SDKVersion() cosmosver.Version {
 func (c ChainCmd) GentxCommand(
 	validatorName string,
 	selfDelegation string,
+	ethAddress string,
+	orchAddress string,
 	options ...GentxOption,
 ) step.Option {
 	command := []string{
 		commandGentx,
 	}
 
-	switch {
-	case c.sdkVersion.LT(cosmosver.StargateFortyVersion):
-		command = append(command,
-			validatorName,
-			optionAmount,
-			selfDelegation,
-		)
-	case c.sdkVersion.GTE(cosmosver.StargateFortyVersion):
-		command = append(command,
-			validatorName,
-			selfDelegation,
-		)
-	case c.sdkVersion.LTE(cosmosver.MaxLaunchpadVersion):
-		command = append(command,
-			optionName,
-			validatorName,
-			optionAmount,
-			selfDelegation,
-		)
+	// Use gravity gentx
+	command = append(command,
+		validatorName,
+		selfDelegation,
+		ethAddress,
+		orchAddress,
+	)
 
-		// Attach home client option
-		if c.cliHome != "" {
-			command = append(command, []string{optionHomeClient, c.cliHome}...)
-		}
+	// Attach home client option
+	if c.cliHome != "" {
+		command = append(command, []string{optionHomeClient, c.cliHome}...)
 	}
 
 	// Apply the options provided by the user

--- a/ignite/pkg/chaincmd/runner/chain.go
+++ b/ignite/pkg/chaincmd/runner/chain.go
@@ -74,6 +74,8 @@ func (r Runner) Gentx(
 	ctx context.Context,
 	validatorName,
 	selfDelegation string,
+	ethAddress string,
+	orchAddress string,
 	options ...chaincmd.GentxOption,
 ) (gentxPath string, err error) {
 	b := &bytes.Buffer{}
@@ -82,7 +84,7 @@ func (r Runner) Gentx(
 		stdout: b,
 		stderr: b,
 		stdin:  os.Stdin,
-	}, r.chainCmd.GentxCommand(validatorName, selfDelegation, options...)); err != nil {
+	}, r.chainCmd.GentxCommand(validatorName, selfDelegation, ethAddress, orchAddress, options...)); err != nil {
 		return "", err
 	}
 

--- a/ignite/services/chain/init.go
+++ b/ignite/services/chain/init.go
@@ -171,6 +171,8 @@ func (c *Chain) InitAccounts(ctx context.Context, conf chainconfig.Config) error
 	_, err = c.IssueGentx(ctx, Validator{
 		Name:          conf.Validator.Name,
 		StakingAmount: conf.Validator.Staked,
+		EthAddress:    conf.Validator.EthAddress,
+		OrchAddress:   conf.Validator.OrchAddress,
 	})
 	return err
 }
@@ -216,6 +218,8 @@ type Validator struct {
 	Name                    string
 	Moniker                 string
 	StakingAmount           string
+	EthAddress              string
+	OrchAddress             string
 	CommissionRate          string
 	CommissionMaxRate       string
 	CommissionMaxChangeRate string

--- a/ignite/services/chain/plugin-stargate.go
+++ b/ignite/services/chain/plugin-stargate.go
@@ -35,6 +35,8 @@ func (p *stargatePlugin) Gentx(ctx context.Context, runner chaincmdrunner.Runner
 		ctx,
 		v.Name,
 		v.StakingAmount,
+		v.EthAddress,
+		v.OrchAddress,
 		chaincmd.GentxWithMoniker(v.Moniker),
 		chaincmd.GentxWithCommissionRate(v.CommissionRate),
 		chaincmd.GentxWithCommissionMaxRate(v.CommissionMaxRate),


### PR DESCRIPTION
This PR alters the ignite cli to use gentx-gravity instead of the basic gentx command.

This is now required to run the chain due to [this bug fix](https://github.com/umee-network/umee/pull/1217#discussion_r948406075) introduced in the sdk 0.46 migration.

Long term, we'll want to stop being dependent on the ignite cli and set up scripts for CI to use instead.

The change we'll add to the starport.ci.yml file will look like this: 

```yml
validator:
  name: alice
  staked: "33500000000000uumee"
  eth_address: "0x9fc56f2e851e1ab2b4c0fc4f6344800f29652ffe"
  orch_address: "umee1zypqa76je7pxsdwkfah6mu9a583sju6xjavygg"
```